### PR TITLE
Update for Gledopto RGB+W / GL-C-007

### DIFF
--- a/app.json
+++ b/app.json
@@ -98,7 +98,7 @@
     },
     "zigbee": {
       "manufacturerName": [ "GLEDOPTO" ],
-      "productId": [ "GLEDOPTO" ],
+      "productId": [ "GLEDOPTO", "GL-C-007" ],
       "deviceId": [528 , 256],
       "profileId": 49246,
       "learnmode": {


### PR DESCRIPTION
For the Gledopto RGB+W Zigbee controller the productId is "GL-C-007"