### PR TITLE
Added GL-G-001P - 12W Led Garden Lamp DW RGB

### DIFF
--- a/app.json
+++ b/app.json
@@ -1256,7 +1256,8 @@
         ],
         "productId": [
           "GL-G-001Z",
-          "GL-G-001ZS"
+          "GL-G-001ZS",
+          "GL-G-001P"
         ],
         "deviceId": [
           528,

--- a/drivers/gl-g-001z/driver.compose.json
+++ b/drivers/gl-g-001z/driver.compose.json
@@ -12,7 +12,7 @@
   },
   "zigbee": {
     "manufacturerName": [ "GLEDOPTO" ],
-    "productId": [ "GL-G-001Z" , "GL-G-001ZS"],
+    "productId": [ "GL-G-001Z" , "GL-G-001ZS" , "GL-G-001P"],
     "deviceId":  [ 528, 544 ],
     "profileId": [ 49246, 260 ],
     "endpoints": {


### PR DESCRIPTION
Ik las dat in de nieuwe Homey versie deviceId en profileId niet meer noodzakelijk zijn, vandaar dat ik deze niet gevuld heb.
De 12W Led Garden Lamp Dual White RGB is gelijk aan de GL-G-001Z, vandaar dat ik deze niet als nieuw device heb gemaakt, maar toegevoegd aan de GL-G-001Z, wellicht dat de naam in het scherm waar je een apparaat kunt kiezen net iets anders moet,
dat laat ik even aan jullie over, bijvoorbeeld GL-G-001Z/P of GL-G-001x, geen idee wat handig is.
Als hij beter wel als apart apparaat moet, kan ik die aanpassing ook wel even maken.

Ik heb de code getest en ik kan de lamp nu netjes bedienen dual white, rgb, brightness, on/off.